### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @scrapezy/mcp MCP Server
 
+<a href="https://glama.ai/mcp/servers/rnktqsouvy">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/rnktqsouvy/badge" alt="Scrapezy MCP server" />
+</a>
+
 [![smithery badge](https://smithery.ai/badge/@Scrapezy/mcp)](https://smithery.ai/server/@Scrapezy/mcp)
 
 A Model Context Protocol server for [Scrapezy](https://scrapezy.com) that enables AI models to extract structured data from websites.


### PR DESCRIPTION
This PR adds a badge for the [Scrapezy](https://glama.ai/mcp/servers/rnktqsouvy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/rnktqsouvy">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/rnktqsouvy/badge" alt="Scrapezy MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.